### PR TITLE
if no PK parameter param.PKs()[0] crash

### DIFF
--- a/plugins/admin/modules/parameter/parameter.go
+++ b/plugins/admin/modules/parameter/parameter.go
@@ -153,7 +153,7 @@ func (param Parameters) WithPKs(id ...string) Parameters {
 func (param Parameters) PKs() []string {
 	pk := param.GetFieldValue(PrimaryKey)
 	if pk == "" {
-		return []string{}
+		return make([]string, 0)
 	}
 	return strings.Split(param.GetFieldValue(PrimaryKey), ",")
 }


### PR DESCRIPTION
Fix  crash